### PR TITLE
Fixing outdated file reference

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(core
   DSPEmulator.cpp
   GeckoCodeConfig.cpp
   GeckoCode.cpp
-  HackConfig.cpp
   HotkeyManager.cpp
   MemTools.cpp
   Movie.cpp
@@ -226,6 +225,7 @@ add_library(core
   PowerPC/JitCommon/JitAsmCommon.cpp
   PowerPC/JitCommon/JitBase.cpp
   PowerPC/JitCommon/JitCache.cpp
+  Primehack/HackConfig.cpp
 )
 
 if(_M_X86)


### PR DESCRIPTION
\> Moved HackConfig.cpp to Primehack
\> Didn't update CMakeLists.txt

Now it should build in Linux and mac using cmake.