### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(inputcommon
   ControllerEmu/ControlGroup/Force.cpp
   ControllerEmu/ControlGroup/MixedTriggers.cpp
   ControllerEmu/ControlGroup/ModifySettingsButton.cpp
+	ControllerEmu/ControlGroup/PrimeHackModes.cpp
   ControllerEmu/ControlGroup/Slider.cpp
   ControllerEmu/ControlGroup/Tilt.cpp
   ControllerEmu/ControlGroup/Triggers.cpp


### PR DESCRIPTION
Fix linker error:

/usr/bin/ld: ../Core/libcore.a(GCPadEmu.cpp.o): in function `GCPad::PrimeControllerMode()':
GCPadEmu.cpp:(.text+0x12bc): undefined reference to `ControllerEmu::PrimeHackModes::GetSelectedDevice() const'
/usr/bin/ld: ../Core/libcore.a(GCPadEmu.cpp.o): in function `GCPad::GCPad(unsigned int)':
GCPadEmu.cpp:(.text+0x2766): undefined reference to `ControllerEmu::PrimeHackModes::PrimeHackModes(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ../Core/libcore.a(GCPadEmu.cpp.o): in function `GCPad::SetPrimeMode(bool)':
GCPadEmu.cpp:(.text+0x12dc): undefined reference to `ControllerEmu::PrimeHackModes::SetSelectedDevice(int)'
/usr/bin/ld: ../Core/libcore.a(WiimoteEmu.cpp.o): in function `WiimoteEmu::Wiimote::PrimeControllerMode()':
WiimoteEmu.cpp:(.text+0x201c): undefined reference to `ControllerEmu::PrimeHackModes::GetSelectedDevice() const'
/usr/bin/ld: ../Core/libcore.a(WiimoteEmu.cpp.o): in function `WiimoteEmu::Wiimote::Wiimote(unsigned int)':
WiimoteEmu.cpp:(.text+0x57f4): undefined reference to `ControllerEmu::PrimeHackModes::PrimeHackModes(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ../Core/libcore.a(WiimoteEmu.cpp.o): in function `WiimoteEmu::Wiimote::SetPrimeMode(bool)':
WiimoteEmu.cpp:(.text+0x203c): undefined reference to `ControllerEmu::PrimeHackModes::SetSelectedDevice(int)'
/usr/bin/ld: ../InputCommon/libinputcommon.a(ControlGroup.cpp.o): in function `ControllerEmu::ControlGroup::LoadConfig(IniFile::Section*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
ControlGroup.cpp:(.text+0x11a0): undefined reference to `ControllerEmu::PrimeHackModes::SetSelectedDevice(int)'
/usr/bin/ld: ../InputCommon/libinputcommon.a(ControlGroup.cpp.o): in function `ControllerEmu::ControlGroup::SaveConfig(IniFile::Section*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
ControlGroup.cpp:(.text+0x2114): undefined reference to `ControllerEmu::PrimeHackModes::GetSelectedDevice() const'
collect2: error: ld returned 1 exit status
make[2]: *** [Source/Core/DolphinWX/CMakeFiles/ishiiruka.dir/build.make:1527: Binaries/ishiiruka] Error 1
make[1]: *** [CMakeFiles/Makefile2:1521: Source/Core/DolphinWX/CMakeFiles/ishiiruka.dir/all] Error 2
make: *** [Makefile:171: all] Error 2